### PR TITLE
Drop UK GB for Brexit

### DIFF
--- a/rates.json
+++ b/rates.json
@@ -62,11 +62,6 @@
 			"standard_rate": 20.0000,
 			"ebook_rate"   : 5.5000
 		},
-		"GB": {
-			"country"      : "United Kingdom",
-			"standard_rate": 20.0000,
-			"ebook_rate"   : 20.0000
-		},
 		"HR": {
 			"country"      : "Croatia",
 			"standard_rate": 25.0000,


### PR DESCRIPTION
Hi @mikejolley. Recently figured out incorrect GB VAT kept coming back because I have `plugins/woocommerce-eu-vat-rates-sync` active.

Is this plugin idea still alive, or should we move on to something else? Cheers, L